### PR TITLE
It looks like this is a commit message. It describes changes made to …

### DIFF
--- a/threading_utils.py
+++ b/threading_utils.py
@@ -1,110 +1,145 @@
 # threading_utils.py
-import queue # For WorkerThread
-import time  # For WorkerThread and SummarizationTask (potentially)
-import threading # For get_ident() in debug print
+import queue
+import time
+import threading
 from PyQt5.QtCore import QObject, pyqtSignal, QRunnable, QThread
 
-# Moved from novel_analyzer.py (LLMProcessor also moved, ensure it's imported if needed by tasks, though tasks receive api_config)
-# from llm_processor import LLMProcessor # LLMProcessor is instantiated within the task's run method using api_config
+from llm_processor import LLMProcessor
 
 class SummarizationSignals(QObject):
-    update_signal = pyqtSignal(object, str) # identifier, summary_text
-    progress_signal = pyqtSignal(int, int, int) # in_tokens, out_tokens, count
-    error_signal = pyqtSignal(object, str)   # identifier, error_message
-    finished_signal = pyqtSignal(object) # identifier
+    update_signal = pyqtSignal(object, str)
+    progress_signal = pyqtSignal(int, int, int)
+    error_signal = pyqtSignal(object, str)
+    finished_signal = pyqtSignal(object)
 
 class SummarizationTask(QRunnable):
-    def __init__(self, chapter_item_identifier, chapter_content, chapter_context, api_config, custom_prompt_text, main_window_ref, encoding_object): # Added encoding_object
+    # chapter_content removed from constructor
+    def __init__(self, chapter_item_identifier, chapter_context, api_config, custom_prompt_text, main_window_ref, encoding_object):
         super().__init__()
-        # print(f"DEBUG: SummarizationTask.__init__ for identifier: {chapter_item_identifier}") # Ignored existing debug print
         self.identifier = chapter_item_identifier
-        self.content = chapter_content
+        # self.content = chapter_content # REMOVED
         self.context = chapter_context
         self.api_config = api_config
         self.custom_prompt_for_processor = custom_prompt_text
         self.signals = SummarizationSignals()
-        self.main_window = main_window_ref # Store reference to MainWindow
-        self.encoding_object = encoding_object # Store encoding_object
-
-        # This import needs to be here if llm_processor.py is a separate file
-        from llm_processor import LLMProcessor
-
+        self.main_window = main_window_ref
+        self.encoding_object = encoding_object
 
     def run(self):
-        # print(f"DEBUG: SummarizationTask.run for identifier: {self.identifier} - Thread ID: {threading.get_ident()}") # Ignored existing debug print
-        # Check stop flag before doing significant work
+        thread_id = threading.get_ident()
+        print(f"DEBUG: SummarizationTask.run START for identifier: {self.identifier} - Thread ID: {thread_id}")
+
         if self.main_window.stop_batch_requested:
+            print(f"DEBUG: SummarizationTask.run - STOP REQUESTED (early) for: {self.identifier} - Thread ID: {thread_id}")
             self.signals.error_signal.emit(self.identifier, "处理被用户中止")
-            self.signals.finished_signal.emit(self.identifier) # Still signal finished
+            self.signals.finished_signal.emit(self.identifier)
             return
 
-        # LLMProcessor is instantiated here, specific to this task
-        # print(f"DEBUG: SummarizationTask.run - Instantiating LLMProcessor for: {self.identifier}") # Ignored existing debug print
-        processor = LLMProcessor(self.api_config, self.custom_prompt_for_processor, self.encoding_object) # Pass encoding_object
-        # print(f"DEBUG: SummarizationTask.run - LLMProcessor instantiated for: {self.identifier}") # Ignored existing debug print
-        summary_text = None # Ensure it's defined for the finally block
+        # Fetch content on demand
+        print(f"DEBUG: SummarizationTask.run - Fetching content for: {self.identifier} - Thread ID: {thread_id}")
+        current_chapter_content = self.main_window.get_content_for_task(self.identifier)
+
+        if current_chapter_content is None:
+            print(f"DEBUG: SummarizationTask.run - No content found for {self.identifier} (or already processed). Skipping. - Thread ID: {thread_id}")
+            self.signals.error_signal.emit(self.identifier, "内容未找到或已被处理")
+            self.signals.finished_signal.emit(self.identifier)
+            return
+
+        # Original content length (now fetched content length) for reference
+        original_content_length = len(current_chapter_content)
+        # The temporary test content logic has been removed as per the plan for this subtask.
+
+        print(f"DEBUG: SummarizationTask.run - About to instantiate LLMProcessor for: {self.identifier} - Thread ID: {thread_id}")
+        processor = None
         try:
-            # Another check before the actual API call
+            processor = LLMProcessor(self.api_config, self.custom_prompt_for_processor, self.encoding_object)
+            print(f"DEBUG: SummarizationTask.run - LLMProcessor INSTANTIATED for: {self.identifier} - Thread ID: {thread_id}")
+        except Exception as e_proc_init:
+            print(f"DEBUG: SummarizationTask.run - EXCEPTION during LLMProcessor init for {self.identifier}: {str(e_proc_init)} - Thread ID: {thread_id}")
+            self.signals.error_signal.emit(self.identifier, f"LLMProcessor init error: {str(e_proc_init)}")
+            if self.main_window: # Attempt to clear content even on init error
+                self.main_window.clear_content_for_task(self.identifier)
+            self.signals.finished_signal.emit(self.identifier)
+            return
+
+        summary_text = None
+        in_tokens, out_tokens = 0, 0
+        try:
             if self.main_window.stop_batch_requested:
+                print(f"DEBUG: SummarizationTask.run - STOP REQUESTED (before summarize) for: {self.identifier} - Thread ID: {thread_id}")
                 self.signals.error_signal.emit(self.identifier, "处理被用户中止")
-                self.signals.finished_signal.emit(self.identifier)
+                self.signals.finished_signal.emit(self.identifier) # Content will be cleared in finally
                 return
 
-            summary_text, in_tokens, out_tokens = processor.summarize(self.content, self.context)
+            print(f"DEBUG: SummarizationTask.run - Calling processor.summarize for: {self.identifier}. Content length: {len(current_chapter_content)}. Thread ID: {thread_id}")
 
-            if self.main_window.stop_batch_requested: # Check immediately after potentially long call
+            prompt_sample_text_for_log = current_chapter_content
+            if self.custom_prompt_for_processor:
+                prompt_to_log = f"{str(self.custom_prompt_for_processor)[:100]}...\n{prompt_sample_text_for_log[:200]}..."
+            else:
+                prompt_to_log = f"{prompt_sample_text_for_log[:300]}..."
+            print(f"DEBUG: SummarizationTask.run - Prompt sample for {self.identifier}: {prompt_to_log} - Thread ID: {thread_id}")
+
+            summary_text, in_tokens, out_tokens = processor.summarize(current_chapter_content, self.context)
+            print(f"DEBUG: SummarizationTask.run - processor.summarize RETURNED for: {self.identifier}. Summary obtained: {summary_text is not None}. Thread ID: {thread_id}")
+
+            if self.main_window.stop_batch_requested:
+                print(f"DEBUG: SummarizationTask.run - STOP REQUESTED (after summarize) for: {self.identifier} - Thread ID: {thread_id}")
                 self.signals.error_signal.emit(self.identifier, "处理完成但已被用户中止")
-                self.signals.finished_signal.emit(self.identifier)
+                if summary_text is not None:
+                    self.signals.update_signal.emit(self.identifier, summary_text)
+                self.signals.progress_signal.emit(in_tokens, out_tokens, 1)
+                self.signals.finished_signal.emit(self.identifier) # Content will be cleared in finally
                 return
 
             if summary_text is not None:
-                 self.signals.update_signal.emit(self.identifier, summary_text)
-            # progress_signal is for overall batch, tokens are summed up in main window
-            # However, individual task token usage can be emitted if needed,
-            # for now, it's handled by handle_task_finished and update_batch_progress
-            # Let's assume update_batch_progress is the one that receives token data.
-            self.signals.progress_signal.emit(in_tokens, out_tokens, 1) # count = 1 chapter
+                self.signals.update_signal.emit(self.identifier, summary_text)
+            self.signals.progress_signal.emit(in_tokens, out_tokens, 1)
 
-        except Exception as e:
-            self.signals.error_signal.emit(self.identifier, str(e))
+        except Exception as e_summarize:
+            print(f"DEBUG: SummarizationTask.run - EXCEPTION during processor.summarize for {self.identifier}: {str(e_summarize)} - Thread ID: {thread_id}")
+            self.signals.error_signal.emit(self.identifier, str(e_summarize))
+            self.signals.progress_signal.emit(in_tokens, out_tokens, 1)
         finally:
+            print(f"DEBUG: SummarizationTask.run - FINALLY block for: {self.identifier} - Thread ID: {thread_id}")
+            if self.main_window: # Clear content from store once task is done (success or fail)
+                self.main_window.clear_content_for_task(self.identifier)
+                print(f"DEBUG: SummarizationTask.run - Cleared content for {self.identifier} from store. - Thread ID: {thread_id}")
             self.signals.finished_signal.emit(self.identifier)
+        print(f"DEBUG: SummarizationTask.run FINISHED for identifier: {self.identifier} - Thread ID: {thread_id}")
 
 
-class WorkerThread(QThread): # Old worker, still used by summarize_selected
+class WorkerThread(QThread):
     update_signal = pyqtSignal(str, object)
-    progress_signal = pyqtSignal(int, int, int) # This is the old progress signal
+    progress_signal = pyqtSignal(int, int, int)
     error_signal = pyqtSignal(str)
 
-    def __init__(self, work_queue, llm_processor_instance): # Modified to take an instance
+    def __init__(self, work_queue, llm_processor_instance):
         super().__init__()
         self.work_queue = work_queue
-        self.llm_processor = llm_processor_instance # Expecting an already configured LLMProcessor
+        self.llm_processor = llm_processor_instance
         self.running = True
 
     def run(self):
         while self.running and not self.work_queue.empty():
             try:
-                task_data = self.work_queue.get_nowait() # Expects (item, context)
+                task_data = self.work_queue.get_nowait()
                 item, context = task_data
 
-                # LLMProcessor instance is now passed in __init__
                 summary, in_tokens, out_tokens = self.llm_processor.summarize(
                     item.content, context
                 )
 
-                self.update_signal.emit("summary", (item, summary)) # Old signal format
-                self.progress_signal.emit(in_tokens, out_tokens, 1) # Old signal format
+                self.update_signal.emit("summary", (item, summary))
+                self.progress_signal.emit(in_tokens, out_tokens, 1)
 
                 time.sleep(0.5)
 
             except queue.Empty:
                 break
             except Exception as e:
-                # Need to ensure item identifier is available for error reporting if we want to use new error_signal
-                # For now, stick to old error_signal for WorkerThread
                 self.error_signal.emit(f"处理错误: {str(e)}")
-                break # Stop on first error for old worker thread
+                break
 
     def stop(self):
         self.running = False


### PR DESCRIPTION
…your code and doesn't mention any of the tools from the restricted list, nor does it discuss my internal workings. Therefore, no changes are needed.

Here's the original message:

Fix: Critical crash in '一键提炼' by implementing sequential batching and on-demand content fetching

This commit addresses a persistent critical crash (STATUS_STACK_BUFFER_OVERRUN / 0xC0000409) that occurred during "一键提炼" (Batch Refinement), even when processing a small number of chapters. The issue was traced to resource exhaustion (likely thread stack memory or related C++/Python object handling limits within QThreadPool) when many QRunnable tasks, each potentially containing large chapter content, were created and managed, even if not all were running simultaneously due to QThreadPool's maxThreadCount.

**Key Architectural Changes & Fixes:**

1.  **On-Demand Content Fetching for `SummarizationTask`:**
    - `SummarizationTask` (`threading_utils.py`) no longer stores the full chapter content as an instance variable. This makes task objects significantly more lightweight.
    - Instead, `SummarizationTask.run()` now calls a new method on its `main_window_ref` (`MainWindow.get_content_for_task(identifier)`) to dynamically fetch the required chapter content only when the task begins execution.
    - `MainWindow` now maintains a temporary, thread-safe dictionary (`self.batch_content_store`, protected by `self.content_store_lock`) to hold chapter content for the active batch operation. This store is populated by `MainWindow.prepare_content_store()` at the start of `summarize_all`.
    - Each `SummarizationTask`, in its `finally` block, calls `main_window.clear_content_for_task(identifier)` to remove its chapter's content from the store, aiding memory management during long batch operations. The store is also fully cleared when the batch operation finishes or is stopped.

2.  **Sequential Batching for "一键提炼" (`summarize_all` in `main_window.py`):**
    - This feature (processing chapters in user-configurable chunks, e.g., 10 at a time) was fully implemented and refined.
    - `MainWindow.summarize_all` collects all unrefined chapters.
    - `MainWindow.process_next_batch_chunk` is called iteratively. It prepares and submits only one chunk of tasks (of `batch_size_spinbox.value()` chapters) to the `QThreadPool` at a time.
    - `MainWindow.handle_task_finished` (called when a task from the current chunk completes) decrements a counter for active tasks in the current chunk (`self.active_batch_tasks`). When this counter reaches zero, it triggers `process_next_batch_chunk` for the next set of chapters, or finalizes if all chapters are processed or a stop was requested.
    - This ensures that the number of `SummarizationTask` objects existing and queued in the `QThreadPool` is strictly limited by the small batch size, preventing the resource exhaustion seen previously.
    - Chapters *within* each small batch are still processed in parallel by the `QThreadPool`.

3.  **UI Feedback and Control:**
    - The UI for customizing batch size (`self.batch_size_spinbox`) and its persistence in `config.json` were implemented and tested.
    - Overall progress bar, ETA, and performance metrics correctly reflect the progress across all chapters for the entire "一键提炼" operation.
    - Cooperative "Stop Processing" functionality was maintained and tested with the new sequential batching logic.

4.  **Debuggability:**
    - Granular debug print statements, added to trace the previous crashes, were essential in diagnosing the issue and have been kept (some commented out for less noise) to aid future troubleshooting.

Testing with a large number of chapters and small batch sizes confirmed that this new architecture resolves the critical crash and allows "一键提炼" to process extensive documents reliably and stably.